### PR TITLE
Add configuration to models

### DIFF
--- a/Sources/SwiftMistralCoreML/ModelActor.swift
+++ b/Sources/SwiftMistralCoreML/ModelActor.swift
@@ -17,6 +17,11 @@ class ModelActor : @unchecked Sendable {
     private var model: Any?
     private var state: Any?
     private var currentModelType: MistralType?
+    private var configuration = MLModelConfiguration()
+
+    init(configuration: MLModelConfiguration) {
+        self.configuration = configuration
+    }
 
     func generateNextToken(
         currentInputIds: [Int],
@@ -249,11 +254,11 @@ class ModelActor : @unchecked Sendable {
         do {
             switch modelType {
             case .int4:
-                let int4Model = try StatefulMistral7BInstructInt4(configuration: MLModelConfiguration())
+                let int4Model = try StatefulMistral7BInstructInt4(configuration: configuration)
                 self.model = int4Model
                 self.state = int4Model.makeState()
             case .fp16:
-                let fp16Model = try StatefulMistral7BInstructFP16(configuration: MLModelConfiguration())
+                let fp16Model = try StatefulMistral7BInstructFP16(configuration: configuration)
                 self.model = fp16Model
                 self.state = fp16Model.makeState()
             }

--- a/Sources/SwiftMistralCoreML/TextGenerator.swift
+++ b/Sources/SwiftMistralCoreML/TextGenerator.swift
@@ -13,8 +13,8 @@ public final class TextGenerator {
     private let tokenizerParser: TokenizerParser
     private let bpeEncoder: BPEEncoder
 
-    public init() throws {
-        self.modelActor = ModelActor()
+    public init(configuration: MLModelConfiguration = MLModelConfiguration()) throws {
+        self.modelActor = ModelActor(configuration: configuration)
         self.tokenizerParser = try TokenizerParser()
         self.bpeEncoder = BPEEncoder(tokenizerParser: tokenizerParser)
     }

--- a/Tests/SwiftMistralCoreMLTests/SwiftMistralCoreMLTests.swift
+++ b/Tests/SwiftMistralCoreMLTests/SwiftMistralCoreMLTests.swift
@@ -1,6 +1,20 @@
 import Testing
 @testable import SwiftMistralCoreML
+import CoreML
 
-@Test func example() async throws {
-    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+@Suite("Text Generator", .serialized) struct TextGeneratorTests {
+
+    @Test("Default model configuration")
+    func textGenerator() async throws {
+        let _ = try TextGenerator()
+    }
+
+
+    @Test("Model configuration",
+          arguments: [MLComputeUnits.cpuOnly, .cpuAndGPU, .all, .cpuAndNeuralEngine])
+    func textGeneratorWithConfiguration(computeUnits: MLComputeUnits) async throws {
+        let configuration = MLModelConfiguration()
+        configuration.computeUnits = computeUnits
+        let _ = try TextGenerator(configuration: configuration)
+    }
 }


### PR DESCRIPTION
Inject model configuration when starting the `TextGenerator`.
Allow to run on CPU, GPU, All or Neural Engine or customize the name.
Add a few tests for it.