### PR TITLE
Fix softmax Float precision bug

### DIFF
--- a/Sources/SwiftMistralCoreML/DecodingStrategy.swift
+++ b/Sources/SwiftMistralCoreML/DecodingStrategy.swift
@@ -62,7 +62,7 @@ struct TopKDecodingStrategy: DecodingStrategy {
     
     private func softmax(_ logits: [Float]) -> [Float] {
         let maxLogit = logits.max() ?? 0.0
-        let exps = logits.map { exp($0 - maxLogit) }
+        let exps = logits.map { expf($0 - maxLogit) }
         let sumExps = exps.reduce(0, +)
         return exps.map { $0 / sumExps }
     }


### PR DESCRIPTION
## Summary
- fix DecodingStrategy.softmax to use `expf` for Float arrays

## Testing
- `swift test` *(fails: no such module 'CoreML')*

------
https://chatgpt.com/codex/tasks/task_e_683ff68dc61883309da9b7855f1723ef